### PR TITLE
Add script for Ruby 2.2.1

### DIFF
--- a/scripts/ruby-2.2.1.sh
+++ b/scripts/ruby-2.2.1.sh
@@ -1,0 +1,23 @@
+# Installs RVM & Ruby 2.2.1 on 12.04 LTS Ubuntu
+# add to Vagrantfile:
+#  config.vm.provision 'shell', path: 'ruby-2.2.1.sh', privileged: false, keep_color: true
+
+if [[ -s "/home/vagrant/.rvm/scripts/rvm" ]] ; then
+  echo 'RVM installed, skipping RVM install'
+else
+  \curl -sSL https://get.rvm.io | bash -s -- --version 1.25.0
+fi
+
+source '/home/vagrant/.rvm/scripts/rvm'
+
+if rvm list strings | grep -lq ruby-2.2.1 ; then
+  echo 'Ruby 2.2.1 installed. Skipping installed.'
+else
+  rvm autolibs packages
+  rvm requirements
+  rvm install 2.2.1
+  rvm use 2.2.1 --default
+  gem update bundler
+fi
+
+echo 'Setting Ruby 2.2.1 as default'


### PR DESCRIPTION
This allows for the install of Ruby 2.2.1 with RVM. As of writing this, there
are no binaries in RVM's hosting dir for Ubuntu 12.04, so this uses the rvm
install command.
