### PR TITLE
Update postgres 9.3 conf to trust all access

### DIFF
--- a/scripts/postgresql93.sh
+++ b/scripts/postgresql93.sh
@@ -58,3 +58,6 @@ if [ ! -d '/usr/local/pgsql/data' ]; then
   # Create vagrant user
   su - postgres -l -c 'createuser vagrant -s'
 fi
+
+# allow the db to accessible on the host machine
+echo "host    all     all   0.0.0.0/0   trust" >> /etc/postgresql/9.3/main/pg_hba.conf


### PR DESCRIPTION
This allows the postgres instance to be accessed at the IP address of
the VM on the host machine. This is useful for sharing databases across
VMs on the host machine.
